### PR TITLE
Refactor conv2d_gw8 to use dimensional projection

### DIFF
--- a/spio/generators/__init__.py
+++ b/spio/generators/__init__.py
@@ -3,7 +3,7 @@
 from .generators import generate
 from .generators_class import Generators
 from .gen_specs import GenSpecs
-from .compound_index import CompoundIndex, CompoundIndexPartition
+from .compound_index import CompoundIndex, CompoundIndexPartition, CoordinatesExpr
 from .tensor import Tensor, CursorInitializer
 from .fragment_type import FragmentType, Operand
 from .data_type import dtype, get_dtype_veclen
@@ -59,4 +59,5 @@ __all__ = GENERATORS + [
     "BuiltIn",
     "LANE",
     "OFFSET",
+    "CoordinatesExpr",
 ]

--- a/spio/generators/dim.py
+++ b/spio/generators/dim.py
@@ -63,6 +63,25 @@ class StaticDim:
             return StaticDim(dim=self.dim, size=self.size * other)
         return self.__mul__(other)
 
+    def __add__(self, other: "StaticDim") -> "StaticDim":
+        """Add two StaticDims with the same base Dim."""
+        if isinstance(other, int):
+            return StaticDim(dim=self.dim, size=self.size + other)
+        if not isinstance(other, StaticDim):
+            return NotImplemented
+        if self.dim is not other.dim:
+            raise TypeError(
+                f"Cannot add StaticDims with different base Dims: "
+                f"{self.dim.dim_name} vs {other.dim.dim_name}"
+            )
+        return StaticDim(dim=self.dim, size=self.size + other.size)
+
+    def __radd__(self, other: int) -> "StaticDim":
+        """Right add - handles int + StaticDim."""
+        if isinstance(other, int):
+            return StaticDim(dim=self.dim, size=self.size + other)
+        return NotImplemented
+
     def fold(self, stride: int) -> "StaticFold":
         """Create a StaticFold of this dimension with the given stride.
 

--- a/spio/generators/generators_class.py
+++ b/spio/generators/generators_class.py
@@ -52,7 +52,11 @@ class Generators:
         elif _is_generator_type(value):
             # Generator objects are registered with the name
             if hasattr(value, "_set_class_name"):
-                value._set_class_name(name)
+                # _set_class_name may return a new object if the original already
+                # has a different name (e.g., cached Fold objects from Dim.fold())
+                result = value._set_class_name(name)
+                if result is not None:
+                    value = result
             elif hasattr(value, "class_name"):
                 # For objects that use class_name directly (legacy support)
                 object.__setattr__(value, "class_name", name)

--- a/spio/generators/params.py
+++ b/spio/generators/params.py
@@ -14,12 +14,12 @@ class ParamsSpec(GenSpecs):
     bool, int, or float.
 
     Attributes:
-        name_space: The name of the C++ namespace.
         params: A dictionary of parameter names and their values.
+        name_space: The name of the C++ namespace.
     """
 
-    name_space: str
     params: Dict[str, Any]
+    name_space: str = None
 
     def generate(self) -> str:
         """Generate the C++ code for the parameter definitions."""
@@ -29,6 +29,13 @@ class ParamsSpec(GenSpecs):
             code += f"    inline constexpr {c_type_name} {name} = {c_value};\n"
         code += "}\n"
         return code
+
+    def _set_class_name(self, class_name: str) -> None:
+        self.name_space = class_name
+
+    def get_class_name(self) -> str:
+        """Return the namespace name (prevents auto-naming)."""
+        return self.name_space
 
 
 def _c_type_name(val: Any) -> Tuple[str, Any]:

--- a/spio/include/spio/meta.h
+++ b/spio/include/spio/meta.h
@@ -492,6 +492,27 @@ namespace spio {
         template <typename FromBaseDim, typename ToBaseDim, typename DimType>
         using replace_base_dim_t = typename replace_base_dim<FromBaseDim, ToBaseDim, DimType>::type;
 
+        // Transform all dimensions in a tuple, replacing FromBaseDim with ToBaseDim
+        template <typename FromBaseDim, typename ToBaseDim, typename Tuple>
+        struct tuple_replace_base_dim;
+
+        template <typename FromBaseDim, typename ToBaseDim>
+        struct tuple_replace_base_dim<FromBaseDim, ToBaseDim, tuple<>> {
+            using type = tuple<>;
+        };
+
+        template <typename FromBaseDim, typename ToBaseDim, typename First, typename... Rest>
+        struct tuple_replace_base_dim<FromBaseDim, ToBaseDim, tuple<First, Rest...>> {
+            using first_replaced = replace_base_dim_t<FromBaseDim, ToBaseDim, First>;
+            using rest_replaced =
+                typename tuple_replace_base_dim<FromBaseDim, ToBaseDim, tuple<Rest...>>::type;
+            using type = tuple_prepend_t<first_replaced, rest_replaced>;
+        };
+
+        template <typename FromBaseDim, typename ToBaseDim, typename Tuple>
+        using tuple_replace_base_dim_t =
+            typename tuple_replace_base_dim<FromBaseDim, ToBaseDim, Tuple>::type;
+
         // ========================================================================
         // Dim-like detection
         // ========================================================================

--- a/spio/include/spio/tensor.h
+++ b/spio/include/spio/tensor.h
@@ -573,11 +573,39 @@ namespace spio {
             return make_sizes_from_infos(coarsest_infos{});
         }
 
-        /// Checks if all coordinates are within bounds.
+        /// Checks if all coordinates are within bounds (upper bound only).
         ///
         /// Returns true if each coordinate is less than the corresponding extent.
+        /// Use in_range() when coordinates may be negative.
         DEVICE constexpr bool inbounds() const {
             return _coords < extents();
+        }
+
+        /// Stores the inbounds() result and returns *this for method chaining.
+        ///
+        /// Enables fluent API patterns like:
+        ///   input = Input(ptr).inbounds(z_inbounds).rebase();
+        DEVICE constexpr Cursor& inbounds(bool& result) {
+            result = inbounds();
+            return *this;
+        }
+
+        /// Checks if all coordinates are within the valid range [0, extent).
+        ///
+        /// Returns true if each coordinate is non-negative and less than the
+        /// corresponding extent. Use this when coordinates may be negative,
+        /// such as when subtracting padding offsets.
+        DEVICE constexpr bool in_range() const {
+            return _coords.all_non_negative() && inbounds();
+        }
+
+        /// Stores the in_range() result and returns *this for method chaining.
+        ///
+        /// Enables fluent API patterns like:
+        ///   input = Input(ptr).in_range(z_inbounds).rebase();
+        DEVICE constexpr Cursor& in_range(bool& result) {
+            result = in_range();
+            return *this;
         }
 
         DEVICE constexpr data_type& operator*() const {

--- a/spio/kernels/conv2d_gw8_wgrad_kernel.py
+++ b/spio/kernels/conv2d_gw8_wgrad_kernel.py
@@ -183,16 +183,15 @@ def _get_kernel_spec(
         Fold("c", block_c, fold_name="block_c"),
         Fold("s", config.warp_s, fold_name="warp_s"),
         ParamsSpec(
-            "Block",
             {
                 "threads": threads,
             },
+            "Block",
         ),
         #
         # Constant parameters.
         #
         ParamsSpec(
-            "Params",
             {
                 "R_Size": r,
                 "S_Size": s,
@@ -205,6 +204,7 @@ def _get_kernel_spec(
                 "BLOCK_N_ITERS": config.block_n_iters,
                 "WARP_N_Size": config.warp_n,
             },
+            "Params",
         ),
         #
         # Block indices.

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -43,8 +43,8 @@ def test_memcpy_kernel():
     my_params_header = generate(
         [
             ParamsSpec(
-                "MyParams",
                 {"ITERS": ITERS, "BLOCK_X4": BLOCK_X4, "X": X, "THREADS": THREADS},
+                "MyParams",
             ),
         ]
     )


### PR DESCRIPTION
## Summary

- Unify spatial dimensions (`H`, `W`) across input, output, and filter tensors to enable proper dimensional projection
- Migrate kernel spec from list-based `gen_specs` to `Generators()` container class
- Add coordinate manipulation methods: `drop<BaseDim>()`, `cast<FromBaseDim, ToBaseDim>()`, `all_non_negative()`
- Add cursor API improvements: `in_range()` for bounds checking with negative coordinates, `inbounds(bool&)` overload for method chaining
- Add `CoordinatesExpr` and `CursorInitializer` generators for cleaner tensor indexing setup
- Simplify conv2d_gw8 kernel code by leveraging dimensional projection

## Test plan

- [x] All conv2d_gw8 smoke tests pass
- [x] New Python tests for dimensions and generators (156 tests)
- [x] New C++ tests for coordinates and cursor initializers (144 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)